### PR TITLE
实现新控制分配计算

### DIFF
--- a/control_allocator_modifications.md
+++ b/control_allocator_modifications.md
@@ -1,0 +1,51 @@
+# Control Allocator 修改总结
+
+## 修改概述
+基于用户提供的控制分配模型，对 Control Allocator 模块进行了修改，实现了自定义的控制分配算法。
+
+## 修改内容
+
+### 1. 头文件修改 (ControlAllocator.hpp)
+- 添加了 `#include <uORB/topics/utrim.h>` 以支持 utrim 消息
+- 添加了 `uORB::Subscription _utrim_sub{ORB_ID(utrim)};` 用于订阅 utrim 消息
+- 添加了 `void calculate_custom_allocation();` 函数声明
+
+### 2. 实现文件修改 (ControlAllocator.cpp)
+- 在 `Run()` 函数中添加了对 `calculate_custom_allocation()` 的调用
+- 实现了 `calculate_custom_allocation()` 函数，包含以下逻辑：
+
+#### 控制分配模型
+实现了用户提供的数学模型：
+
+$$\begin{bmatrix} df_x \\ df_z \\ d\tau_x/L_3 \\ d\tau_y/L_1 \\ d\tau_z/L_3 \end{bmatrix}= \begin{bmatrix} \sin\theta_1 & \sin\theta_2 & \sin\theta_3 & \cos\theta_1 & \cos\theta_2 & \cos\theta_3 \\ -\cos\theta_1 & -\cos\theta_2 & -\cos\theta_3 & \sin\theta_1 & \sin\theta_2 & \sin\theta_3 \\ -\cos\theta_1 & \cos\theta_2 & 0 & \sin\theta_1 & -\sin\theta_2 & 0 \\ \cos\theta_1 & \cos\theta_2 & -\left(L_2/L_1\right)\cos\theta_3 & -\sin\theta_1 & -\sin\theta_2 & \left(L_2/L_1\right)\sin\theta_3 \\ -\sin\theta_1 & \sin\theta_2 & 0 & -\cos\theta_1 & \cos\theta_2 & 0 \end{bmatrix} \begin{bmatrix} df_1 \\ df_2 \\ df_3 \\ df_1d\theta_1 \\ f_2d\theta_2 \\ f_3d\theta_3 \end{bmatrix}$$
+
+#### 实现细节
+1. **输入获取**：
+   - 从 `_thrust_sp(0)` 和 `_thrust_sp(2)` 获取 fx 和 fz
+   - 从 utrim 消息的 `polynomial_values[0-2]` 获取 θ1、θ2、θ3
+
+2. **常量定义**：
+   - L1 = 1.0f
+   - L2 = 1.0f  
+   - L3 = 1.0f
+
+3. **矩阵构建**：
+   - 构建 5x6 的效率矩阵 A
+   - 构建 5x1 的左侧向量 b (fx, fz, 0, 0, 0)
+
+4. **求解算法**：
+   - 使用伪逆方法：x = A^T * (A * A^T)^{-1} * b
+   - 计算右侧向量 [df1, df2, df3, df1_dtheta1, df2_dtheta2, df3_dtheta3]
+
+5. **输出日志**：
+   - 记录输入参数 (fx, fz, θ1, θ2, θ3)
+   - 记录计算结果向量的所有6个分量
+
+## 功能说明
+- 每个控制循环都会调用自定义分配算法
+- 通过 `PX4_INFO` 输出详细的计算结果
+- 采用MVP原则，仅实现核心功能和日志输出
+- 使用伪逆方法求解超定方程组
+
+## 验证
+代码已经实现并可以通过 `make px4_sitl_default` 命令进行编译验证。

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -470,6 +470,9 @@ ControlAllocator::Run()
 		_last_status_pub = now;
 	}
 
+	// Call custom allocation calculation
+	calculate_custom_allocation();
+
 	perf_end(_loop_perf);
 }
 
@@ -603,6 +606,114 @@ ControlAllocator::update_effectiveness_matrix_if_needed(EffectivenessUpdateReaso
 
 		trims.timestamp = hrt_absolute_time();
 		_actuator_servos_trim_pub.publish(trims);
+	}
+}
+
+void
+ControlAllocator::calculate_custom_allocation()
+{
+	// 检查是否有有效的推力设定点
+	if (!PX4_ISFINITE(_thrust_sp(0)) || !PX4_ISFINITE(_thrust_sp(2))) {
+		return;
+	}
+
+	// 订阅utrim消息
+	utrim_s utrim{};
+	if (!_utrim_sub.update(&utrim) || !utrim.valid) {
+		return;
+	}
+
+	// 从utrim获取三个多项式值作为theta (使用前3个多项式值)
+	float theta1 = utrim.polynomial_values[0];
+	float theta2 = utrim.polynomial_values[1];
+	float theta3 = utrim.polynomial_values[2];
+
+	// 常量定义
+	const float L1 = 1.0f;  // 常量 L1
+	const float L2 = 1.0f;  // 常量 L2
+	const float L3 = 1.0f;  // 常量 L3
+
+	// 从推力设定点获取fx和fz
+	float fx = _thrust_sp(0);
+	float fz = _thrust_sp(2);
+
+	// 计算三角函数值
+	float sin_theta1 = sinf(theta1);
+	float cos_theta1 = cosf(theta1);
+	float sin_theta2 = sinf(theta2);
+	float cos_theta2 = cosf(theta2);
+	float sin_theta3 = sinf(theta3);
+	float cos_theta3 = cosf(theta3);
+
+	// 构建效率矩阵 A (5x6)
+	matrix::Matrix<float, 5, 6> A;
+
+	// 第一行 (fx)
+	A(0, 0) = sin_theta1;
+	A(0, 1) = sin_theta2;
+	A(0, 2) = sin_theta3;
+	A(0, 3) = cos_theta1;
+	A(0, 4) = cos_theta2;
+	A(0, 5) = cos_theta3;
+
+	// 第二行 (fz)
+	A(1, 0) = -cos_theta1;
+	A(1, 1) = -cos_theta2;
+	A(1, 2) = -cos_theta3;
+	A(1, 3) = sin_theta1;
+	A(1, 4) = sin_theta2;
+	A(1, 5) = sin_theta3;
+
+	// 第三行 (d*tau_x/L3)
+	A(2, 0) = -cos_theta1;
+	A(2, 1) = cos_theta2;
+	A(2, 2) = 0.0f;
+	A(2, 3) = sin_theta1;
+	A(2, 4) = -sin_theta2;
+	A(2, 5) = 0.0f;
+
+	// 第四行 (d*tau_y/L1)
+	A(3, 0) = cos_theta1;
+	A(3, 1) = cos_theta2;
+	A(3, 2) = -(L2 / L1) * cos_theta3;
+	A(3, 3) = -sin_theta1;
+	A(3, 4) = -sin_theta2;
+	A(3, 5) = (L2 / L1) * sin_theta3;
+
+	// 第五行 (d*tau_z/L3)
+	A(4, 0) = -sin_theta1;
+	A(4, 1) = sin_theta2;
+	A(4, 2) = 0.0f;
+	A(4, 3) = -cos_theta1;
+	A(4, 4) = cos_theta2;
+	A(4, 5) = 0.0f;
+
+	// 左侧向量 b (5x1)
+	matrix::Vector<float, 5> b;
+	b(0) = fx;
+	b(1) = fz;
+	b(2) = 0.0f; // dtau_x/L3
+	b(3) = 0.0f; // dtau_y/L1
+	b(4) = 0.0f; // dtau_z/L3
+
+	// 计算右侧向量 x = A^T * (A * A^T)^{-1} * b (伪逆解)
+	matrix::Matrix<float, 6, 5> At = A.transpose();
+	matrix::Matrix<float, 5, 5> AAt = A * At;
+	matrix::Matrix<float, 5, 5> AAt_inv;
+
+	// 计算逆矩阵
+	if (matrix::inv(AAt, AAt_inv)) {
+		matrix::Vector<float, 6> x = At * AAt_inv * b;
+
+		// 记录结果
+		PX4_INFO("CustomAllocation: 输入 fx=%.3f, fz=%.3f, theta1=%.3f, theta2=%.3f, theta3=%.3f",
+		         (double)fx, (double)fz, (double)theta1, (double)theta2, (double)theta3);
+
+		PX4_INFO("CustomAllocation: 结果向量 df1=%.3f, df2=%.3f, df3=%.3f, df1_dtheta1=%.3f, df2_dtheta2=%.3f, df3_dtheta3=%.3f",
+		         (double)x(0), (double)x(1), (double)x(2), (double)x(3), (double)x(4), (double)x(5));
+
+	} else {
+		PX4_WARN("CustomAllocation: 无法计算矩阵逆");
 	}
 }
 

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -78,6 +78,7 @@
 #include <uORB/topics/vehicle_thrust_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/failure_detector_status.h>
+#include <uORB/topics/utrim.h>
 
 class ControlAllocator : public ModuleBase<ControlAllocator>, public ModuleParams, public px4::ScheduledWorkItem
 {
@@ -138,6 +139,11 @@ private:
 
 	void publish_actuator_controls();
 
+	/**
+	 * Custom control allocation calculation based on matrix formula
+	 */
+	void calculate_custom_allocation();
+
 	AllocationMethod _allocation_method_id{AllocationMethod::NONE};
 	ControlAllocation *_control_allocation[ActuatorEffectiveness::MAX_NUM_MATRICES] {}; 	///< class for control allocation calculations
 	int _num_control_allocation{0};
@@ -179,6 +185,8 @@ private:
 
 	uORB::Subscription _vehicle_torque_setpoint1_sub{ORB_ID(vehicle_torque_setpoint), 1};  /**< vehicle torque setpoint subscription (2. instance) */
 	uORB::Subscription _vehicle_thrust_setpoint1_sub{ORB_ID(vehicle_thrust_setpoint), 1};	 /**< vehicle thrust setpoint subscription (2. instance) */
+
+	uORB::Subscription _utrim_sub{ORB_ID(utrim)};  /**< utrim subscription for custom allocation */
 
 	// Outputs
 	uORB::PublicationMulti<control_allocator_status_s> _control_allocator_status_pub[2] {ORB_ID(control_allocator_status), ORB_ID(control_allocator_status)};


### PR DESCRIPTION
```
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

%23%23%23 Solved Problem
The existing control allocator did not support a specific custom allocation model based on a given 5x6 matrix formula, which was required for calculating specific force and torque contributions from individual actuators and their derivatives. This PR implements that model.

Fixes %23N/A (No specific GitHub issue ID provided)

%23%23%23 Solution
- Added a new function `calculate_custom_allocation()` to `ControlAllocator.cpp`.
- Subscribed to the `utrim` uORB topic to obtain `theta` values for the allocation matrix.
- Implemented the custom 5x6 matrix-based control allocation model using `_thrust_sp(0)` (fx) and `_thrust_sp(2)` (fz) as inputs for the left-hand side vector.
- Used constant values for `L1, L2, L3` (set to 1.0f).
- Calculated the right-hand side vector (df1, df2, df3, df1_dtheta1, df2_dtheta2, df3_dtheta3) using a pseudo-inverse approach.
- Logged the input parameters (fx, fz, theta1, theta2, theta3) and the calculated 6-element output vector.
- Integrated the call to `calculate_custom_allocation()` within `ControlAllocator::Run()`.

%23%23%23 Changelog Entry
For release notes:
```
Feature: Added experimental custom control allocation model based on a 5x6 matrix.
New parameter: None
Documentation: N/A
```

%23%23%23 Alternatives
The standard control allocation methods are available. This change implements a specific user-requested model for logging purposes.

%23%23%23 Test coverage
- Unit/integration test: None added.
- Simulation/hardware testing logs: N/A. Verified by compilation (`make px4_sitl_default`).

%23%23%23 Context
This PR implements a specific control allocation model as requested by the user, defined by the following matrix equation:
$\begin{aligned} 