### PR TITLE
集成自定义分配到运行

### DIFF
--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -413,6 +413,9 @@ ControlAllocator::Run()
 
 		update_effectiveness_matrix_if_needed(EffectivenessUpdateReason::NO_EXTERNAL_UPDATE);
 
+		// 首先尝试自定义分配
+		calculate_custom_allocation();
+
 		// Set control setpoint vector(s)
 		matrix::Vector<float, NUM_AXES> c[ActuatorEffectiveness::MAX_NUM_MATRICES];
 		c[0](0) = _torque_sp(0);
@@ -440,11 +443,31 @@ ControlAllocator::Run()
 
 			_control_allocation[i]->setControlSetpoint(c[i]);
 
-			// Do allocation
-			_control_allocation[i]->allocate();
-			_actuator_effectiveness->allocateAuxilaryControls(dt, i, _control_allocation[i]->_actuator_sp); //flaps and spoilers
-			_actuator_effectiveness->updateSetpoint(c[i], i, _control_allocation[i]->_actuator_sp,
+			// 尝试使用自定义分配
+			if (_custom_allocation_valid) {
+				// 使用自定义分配结果
+				matrix::Vector<float, NUM_ACTUATORS> custom_actuator_sp;
+				if (apply_custom_allocation(custom_actuator_sp)) {
+					_control_allocation[i]->setActuatorSetpoint(custom_actuator_sp);
+					PX4_INFO("使用自定义控制分配");
+				} else {
+					// 回退到标准分配
+					_control_allocation[i]->allocate();
+				}
+			} else {
+				// 回退到标准分配
+				_control_allocation[i]->allocate();
+			}
+			
+			// 获取当前的执行器设定点用于后续处理
+			matrix::Vector<float, NUM_ACTUATORS> actuator_sp = _control_allocation[i]->getActuatorSetpoint();
+			
+			_actuator_effectiveness->allocateAuxilaryControls(dt, i, actuator_sp); //flaps and spoilers
+			_actuator_effectiveness->updateSetpoint(c[i], i, actuator_sp,
 								_control_allocation[i]->getActuatorMin(), _control_allocation[i]->getActuatorMax());
+			
+			// 更新执行器设定点
+			_control_allocation[i]->setActuatorSetpoint(actuator_sp);
 
 			if (_has_slew_rate) {
 				_control_allocation[i]->applySlewRateLimit(dt);
@@ -468,9 +491,6 @@ ControlAllocator::Run()
 
 		_last_status_pub = now;
 	}
-
-	// Call custom allocation calculation
-	calculate_custom_allocation();
 
 	perf_end(_loop_perf);
 }
@@ -611,6 +631,9 @@ ControlAllocator::update_effectiveness_matrix_if_needed(EffectivenessUpdateReaso
 void
 ControlAllocator::calculate_custom_allocation()
 {
+	// 重置有效性标志
+	_custom_allocation_valid = false;
+	
 	// 检查是否有有效的推力设定点
 	if (!PX4_ISFINITE(_thrust_sp(0)) || !PX4_ISFINITE(_thrust_sp(2))) {
 		return;
@@ -626,15 +649,27 @@ ControlAllocator::calculate_custom_allocation()
 	float theta1 = utrim.polynomial_values[0];
 	float theta2 = utrim.polynomial_values[1];
 	float theta3 = utrim.polynomial_values[2];
+	float f1 = utrim.polynomial_values[3];
+	float f2 = utrim.polynomial_values[4];
+	float f3 = utrim.polynomial_values[5];
+
+	// 角度转弧度，使用 PX4 自带的 M_PI_F
+	theta1 *= (M_PI_F / 180.0f);
+	theta2 *= (M_PI_F / 180.0f);
+	theta3 *= (M_PI_F / 180.0f);
 
 	// 常量定义
-	const float L1 = 1.0f;  // 常量 L1
+	const float L1 = 0.20f;  // 常量 L1
 	const float L2 = 1.0f;  // 常量 L2
-	const float L3 = 1.0f;  // 常量 L3
+	const float L3 = 0.41f;  // 常量 L3
 
 	// 从推力设定点获取fx和fz
 	float fx = _thrust_sp(0);
 	float fz = _thrust_sp(2);
+
+	float tau_x = _torque_sp(0);
+	float tau_y = _torque_sp(1);
+	float tau_z = _torque_sp(2);
 
 	// 计算三角函数值
 	float sin_theta1 = sinf(theta1);
@@ -644,7 +679,7 @@ ControlAllocator::calculate_custom_allocation()
 	float sin_theta3 = sinf(theta3);
 	float cos_theta3 = cosf(theta3);
 
-	// 构建效率矩阵 A (5x6)
+	// 构建效率矩阵 A (5x6) Control Effectiveness Matrix
 	matrix::Matrix<float, 5, 6> A;
 
 	// 第一行 (fx)
@@ -691,29 +726,61 @@ ControlAllocator::calculate_custom_allocation()
 	matrix::Vector<float, 5> b;
 	b(0) = fx;
 	b(1) = fz;
-	b(2) = 0.0f; // dtau_x/L3
-	b(3) = 0.0f; // dtau_y/L1
-	b(4) = 0.0f; // dtau_z/L3
+	b(2) = tau_x / L3; // dtau_x/L3
+	b(3) = tau_y / L1; // dtau_y/L1
+	b(4) = tau_z / L3; // dtau_z/L3
 
-	// 计算右侧向量 x = A^T * (A * A^T)^{-1} * b (伪逆解)
+	// 计算右侧向量 du = A^T * (A * A^T)^{-1} * b (伪逆解)
 	matrix::Matrix<float, 6, 5> At = A.transpose();
 	matrix::Matrix<float, 5, 5> AAt = A * At;
 	matrix::Matrix<float, 5, 5> AAt_inv;
 
 	// 计算逆矩阵
-	if (matrix::inv(AAt, AAt_inv)) {
-		matrix::Vector<float, 6> x = At * AAt_inv * b;
+	if (matrix::geninv(AAt, AAt_inv)) {
+		matrix::Vector<float, 6> du = At * AAt_inv * b;
+
+		// du 后三个量分别除以 f1 f2 f3
+		du(3) /= f1;
+		du(4) /= f2;
+		du(5) /= f3;
+
+		// 存储结果
+		_custom_allocation_result = du;
+		_custom_allocation_valid = true;
 
 		// 记录结果
 		PX4_INFO("CustomAllocation: 输入 fx=%.3f, fz=%.3f, theta1=%.3f, theta2=%.3f, theta3=%.3f",
 		         (double)fx, (double)fz, (double)theta1, (double)theta2, (double)theta3);
 
-		PX4_INFO("CustomAllocation: 结果向量 df1=%.3f, df2=%.3f, df3=%.3f, df1_dtheta1=%.3f, df2_dtheta2=%.3f, df3_dtheta3=%.3f",
-		         (double)x(0), (double)x(1), (double)x(2), (double)x(3), (double)x(4), (double)x(5));
+		PX4_INFO("CustomAllocation: 结果向量 du1=%.3f, du2=%.3f, du3=%.3f, du1_dtheta1=%.3f, du2_dtheta2=%.3f, du3_dtheta3=%.3f",
+		         (double)du(0), (double)du(1), (double)du(2), (double)du(3), (double)du(4), (double)du(5));
 
 	} else {
 		PX4_WARN("CustomAllocation: 无法计算矩阵逆");
 	}
+}
+
+bool
+ControlAllocator::apply_custom_allocation(matrix::Vector<float, NUM_ACTUATORS> &actuator_sp)
+{
+	if (!_custom_allocation_valid) {
+		return false;
+	}
+
+	// 清零执行器设定点
+	actuator_sp.setZero();
+
+	// 映射电机输出 (du[0:3] -> actuator_sp[0:3])
+	for (int i = 0; i < 3; i++) {
+		actuator_sp(i) = _custom_allocation_result(i);
+	}
+
+	// 映射舵机输出 (du[3:6] -> actuator_sp[3:6])
+	for (int i = 0; i < 3; i++) {
+		actuator_sp(i + 3) = _custom_allocation_result(i + 3);
+	}
+
+	return true;
 }
 
 void

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -143,6 +143,11 @@ private:
 	 * Custom control allocation calculation based on matrix formula
 	 */
 	void calculate_custom_allocation();
+	
+	/**
+	 * Apply custom allocation results to actuator setpoints
+	 */
+	bool apply_custom_allocation(matrix::Vector<float, NUM_ACTUATORS> &actuator_sp);
 
 	AllocationMethod _allocation_method_id{AllocationMethod::NONE};
 	ControlAllocation *_control_allocation[ActuatorEffectiveness::MAX_NUM_MATRICES] {}; 	///< class for control allocation calculations
@@ -204,6 +209,10 @@ private:
 	matrix::Vector3f _torque_sp;
 	matrix::Vector3f _thrust_sp;
 	bool _publish_controls{true};
+	
+	// Custom allocation results
+	matrix::Vector<float, 6> _custom_allocation_result;
+	bool _custom_allocation_valid{false};
 
 	// Reflects motor failures that are currently handled, not motor failures that are reported.
 	// For example, the system might report two motor failures, but only the first one is handled by CA


### PR DESCRIPTION
```
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

%23%23%23 Solved Problem
A custom control allocation algorithm, implemented in `calculate_custom_allocation`, was not being utilized by the main `ControlAllocator::Run()` function. This prevented the application of new logic for motor output forces and servo tilt angles.

%23%23%23 Solution
- Integrated the `calculate_custom_allocation()` function into `ControlAllocator::Run()`.
- Added `apply_custom_allocation()` to map the custom allocation results (motor forces `du[0:3]` and servo angles `du[3:6]`) to the actuator setpoints.
- Implemented a fallback mechanism: if the custom allocation is not valid or fails, the system reverts to the standard control allocation.
- Introduced a `_custom_allocation_valid` flag to indicate the success of the custom allocation.
- Ensured correct usage of `getActuatorSetpoint()` and `setActuatorSetpoint()` for updating actuator outputs.

%23%23%23 Changelog Entry
For release notes:
```
Feature: Custom control allocation integration.
```

%23%23%23 Alternatives
None discussed.

%23%23%23 Test coverage
- Unit/integration test: None specifically added.
- Simulation/hardware testing logs: N/A

%23%23%23 Context
This change integrates a user-provided custom control allocation algorithm into the `ControlAllocator` module. The implementation follows the MVP (Minimum Viable Product) principle, making minimal necessary changes to replace the existing allocation logic with the custom one, while providing a robust fallback.
```